### PR TITLE
Database/add reference url

### DIFF
--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -8,6 +8,7 @@ class Recipe < ApplicationRecord
 
   validate :content_is_acceptable
   validate :photo_url_resembles_a_url
+  validate :reference_url_resembles_a_url
 
   def content_is_acceptable
       begin
@@ -25,6 +26,12 @@ class Recipe < ApplicationRecord
     if photo_url.present?
       # not checking for ending in .jpg, .png, etc, because many images are served from routes without valid image file extensions.
       errors.add(:photo_url, "must be valid http or https url") unless /^https?:\/\// =~ photo_url
+    end
+  end
+
+  def reference_url_resembles_a_url
+    if reference_url.present?
+      errors.add(:reference_url, "must be valid http or https url") unless /^https?:\/\// =~ reference_url
     end
   end
 end

--- a/db/migrate/20180510202117_add_reference_url_to_recipes.rb
+++ b/db/migrate/20180510202117_add_reference_url_to_recipes.rb
@@ -1,0 +1,5 @@
+class AddReferenceUrlToRecipes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :recipes, :reference_url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_04_202359) do
+ActiveRecord::Schema.define(version: 2018_05_10_202117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2018_05_04_202359) do
     t.text "photo_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "reference_url"
     t.index ["user_id"], name: "index_recipes_on_user_id"
   end
 


### PR DESCRIPTION
New database migration to add reference_url column to recipes table. Column is optional, but if present must resemble a url, and begin with http:// or https://